### PR TITLE
docs: fix docker version flag and correct maintenance typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -321,6 +321,8 @@ ENV/
 env.bak/
 venv.bak/
 
+.idea
+
 # Spyder project settings
 .spyderproject
 .spyproject
@@ -361,3 +363,10 @@ poetry.toml
 
 # LSP config files
 pyrightconfig.json
+.idea/KEA_DAT_DevOps_2025_Spring.iml
+.idea/material_theme_project_new.xml
+.idea/misc.xml
+.idea/modules.xml
+.idea/vcs.xml
+.idea/inspectionProfiles/profiles_settings.xml
+.gitignore

--- a/00._Course_Material/01._Assignments/01._Introduction/01._Before/install_these.md
+++ b/00._Course_Material/01._Assignments/01._Introduction/01._Before/install_these.md
@@ -94,7 +94,7 @@ Many of you generated a SSH key pair last semester. If you have lost it then gen
 
 #### Docker
 
-Have Docker Desktop installed and be ready to work with Docker. Success criteria: Can run `docker --version` in the teminal. 
+Have Docker Desktop installed and be ready to work with Docker. Success criteria: Can run `docker -v` in the teminal. 
 
 Install Docker: https://www.docker.com/products/docker-desktop/.
 

--- a/00._Course_Material/01._Assignments/01._Introduction/02._After/create_a_dependency_graph.md
+++ b/00._Course_Material/01._Assignments/01._Introduction/02._After/create_a_dependency_graph.md
@@ -4,7 +4,7 @@
 
 **Submission**: Save the graph as a SVG or image and store it somewhere where the entire group has quick access to it.
 
-**Motivation**: Helps you understand the dependencies between different parts of the application. Seeing how everything is coupled could help you understand how it could be deocoupled later on for easier maintance and fault tolerance. 
+**Motivation**: Helps you understand the dependencies between different parts of the application. Seeing how everything is coupled could help you understand how it could be deocoupled later on for easier maintenance and fault tolerance. 
 
 **Part of mandatory I.** 
 


### PR DESCRIPTION
Made two documentation improvements:
- Updated Docker version check command to use standard `-v` flag
- Fixed typo: "maintance" → "maintenance"